### PR TITLE
Local compute for demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,19 @@ The following environment variables can be specified. They can be provided via a
 * MOS_COMPUTE_CONN_RETRIES_INT:
 * MOS_COMPUTE_CONN_RETRIES_MAX:
 
+### MOS Demo Configuration
+
+To enable a compute worker to server model run requests from the [MOS demo](https://github.com/Fuinn/mos-demo), specify the following values:
+
+* MOS_BACKEND_HOST=localhost
+* MOS_BACKEND_PORT=8000
+* MOS_ADMIN_USR=mos
+* MOS_ADMIN_PWD=demo
+* MOS_RABBIT_PORT=5672  
+* MOS_RABBIT_USR=guest
+* MOS_RABBIT_PWD=guest
+* MOS_RABBIT_HOST=localhost
+
 ## Local Deployment
 
 Launch a Python worker by executing ``./workers/worker.py``.

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ The following environment variables can be specified. They can be provided via a
 * MOS_COMPUTE_CONN_RETRIES_INT:
 * MOS_COMPUTE_CONN_RETRIES_MAX:
 
-### MOS Demo Configuration
+### Configuration for MOS Demo
 
-To enable a compute worker to server model run requests from the [MOS demo](https://github.com/Fuinn/mos-demo), specify the following values:
+To enable a compute worker to work with the [MOS demo](https://github.com/Fuinn/mos-demo) on the same machine, specify the following values:
 
 * MOS_BACKEND_HOST=localhost
 * MOS_BACKEND_PORT=8000


### PR DESCRIPTION
To run demo without workers, and provide workers from your own environment.